### PR TITLE
IPv6 support (among other things)

### DIFF
--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -60,9 +60,6 @@ defmodule CIDR do
   defp parse(address, mask) do
     %CIDR{ip: address, mask: mask}
   end
-  defp parse(address, mask) do
-    {:error, "Could not parse: #{:inet.ntoa(address)}/#{inspect mask}"}
-  end
 
   @doc """
   Returns the number of hosts covered.

--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -81,19 +81,19 @@ defmodule CIDR do
   # Validate that mask is valid
   defp parse(address, mask) when
       tuple_size(address) == 4 and
-      (mask < 0) or (mask > 32) do
+      ((mask < 0) or (mask > 32)) do
     {:error, "Invalid mask #{mask}"}
   end
   defp parse(address, mask) when
       tuple_size(address) == 8 and
-      (mask < 0) or (mask > 128) do
+      ((mask < 0) or (mask > 128)) do
     {:error, "Invalid mask #{mask}"}
   end
   # Everything is fine
   defp parse(address, mask) when tuple_size(address) == 4 do
     create(start_address(address, mask), end_address(address, mask), mask, hosts(:ipv4, mask))
   end
-  defp parse(address, mask) when tuple_size(address) == 6 do
+  defp parse(address, mask) when tuple_size(address) == 8 do
     create(start_address(address, mask), end_address(address, mask), mask, hosts(:ipv6, mask))
   end
 
@@ -126,6 +126,19 @@ defmodule CIDR do
     d1  = ((x >>>  0) &&& 0xFF)
     { a1, b1, c1, d1 }
   end
+  defp start_address({a, b, c, d, e, f, g, h}, mask) do
+    s   = (128 - mask)
+    x   = (((a <<< 112) ||| (b <<< 96) ||| (c <<< 80) ||| (d <<< 64) ||| (e <<< 48) ||| (f <<< 32) ||| (g <<< 16) ||| h) >>> s) <<< s
+    a1  = ((x >>> 112) &&& 0xFFFF)
+    b1  = ((x >>>  96) &&& 0xFFFF)
+    c1  = ((x >>>  80) &&& 0xFFFF)
+    d1  = ((x >>>  64) &&& 0xFFFF)
+    e1  = ((x >>>  48) &&& 0xFFFF)
+    f1  = ((x >>>  32) &&& 0xFFFF)
+    g1  = ((x >>>  16) &&& 0xFFFF)
+    h1  = ((x >>>   0) &&& 0xFFFF)
+    { a1, b1, c1, d1, e1, f1, g1, h1 }
+  end
 
   defp end_address({a, b, c, d}, mask) do
     s   = (32 - mask)
@@ -136,6 +149,20 @@ defmodule CIDR do
     c1  = ((y >>>  8) &&& 0xFF)
     d1  = ((y >>>  0) &&& 0xFF)
     { a1, b1, c1, d1 }
+  end
+  defp end_address({a, b, c, d, e, f, g, h}, mask) do
+    s   = (128 - mask)
+    x   = (((a <<< 112) ||| (b <<< 96) ||| (c <<< 80) ||| (d <<< 64) ||| (e <<< 48) ||| (f <<< 32) ||| (g <<< 16) ||| h) >>> s) <<< s
+    y   = x ||| ((1 <<< s) - 1)
+    a1  = ((y >>> 112) &&& 0xFFFF)
+    b1  = ((y >>>  96) &&& 0xFFFF)
+    c1  = ((y >>>  80) &&& 0xFFFF)
+    d1  = ((y >>>  64) &&& 0xFFFF)
+    e1  = ((y >>>  48) &&& 0xFFFF)
+    f1  = ((y >>>  32) &&& 0xFFFF)
+    g1  = ((y >>>  16) &&& 0xFFFF)
+    h1  = ((y >>>   0) &&& 0xFFFF)
+    { a1, b1, c1, d1, e1, f1, g1, h1 }
   end
 
   defp is_ipv6({a, b, c, d, e, f, g, h}) do

--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -26,43 +26,42 @@ defmodule CIDR do
   end
   def match(_address, _mask), do: false
 
-  @doc "Parses a bitstring into a CIDR struct"
+  @doc """
+  Parses a bitstring into a CIDR struct
+  """
   def parse(string) when string |> is_bitstring do
     [address | mask]  = string |> String.split("/")
     ip_address = address |> String.to_char_list |> :inet.parse_address
-    do_parse(ip_address, mask)
-  end
 
-  @doc "Only bitstrings can be parsed"
+    case ip_address do
+      {:ok, address}   -> parse(address, mask)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+  # Only bitstrings can be parsed
   def parse(_other) do
     {:error, "Not a bitstring"}
   end
 
-  # :inet.parse_address failed, so we pass the reason to the caller
-  defp do_parse({:error, reason}, _) do
-    {:error, reason}
-  end
-
   # We got a simple IP address without mask
-  defp do_parse({:ok, address}, []) do
+  defp parse(address, []) do
     %CIDR{ip: address, mask: address |> mask_by_ip}
   end
   # We got a mask and need to convert it to integer
-  defp do_parse({:ok, address}, [mask]) do
-    do_parse({:ok, address}, mask |> int)
+  defp parse(address, [mask]) do
+    parse(address, mask |> int)
   end
   # Validate that mask in valid
   # TODO: Add IPv6 support
-  defp do_parse({:ok, _address}, mask) when (mask < 0) or (mask > 32) do
+  defp parse(_address, mask) when (mask < 0) or (mask > 32) do
     {:error, "Invalid mask #{mask}"}
   end
   # Everything is fine
-  defp do_parse({:ok, address}, mask) do
+  defp parse(address, mask) do
     %CIDR{ip: address, mask: mask}
   end
-  # Otherwise, return error
-  defp do_parse(ip_address, mask) do
-    {:error, "Could not parse ip address #{inspect ip_address} and mask #{inspect mask}"}
+  defp parse(address, mask) do
+    {:error, "Could not parse: #{:inet.ntoa(address)}/#{inspect mask}"}
   end
 
   @doc """

--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -76,9 +76,15 @@ defmodule CIDR do
   defp parse(address, [mask]) do
     parse(address, mask |> int)
   end
-  # Validate that mask in valid
-  # TODO: Add IPv6 support
-  defp parse(_address, mask) when (mask < 0) or (mask > 32) do
+  # Validate that mask is valid
+  defp parse(address, mask) when
+      tuple_size(address) == 4 and
+      (mask < 0) or (mask > 32) do
+    {:error, "Invalid mask #{mask}"}
+  end
+  defp parse(address, mask) when
+      tuple_size(address) 8 and
+      (mask < 0) or (mask > 128) do
     {:error, "Invalid mask #{mask}"}
   end
   # Everything is fine

--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -19,9 +19,9 @@ defmodule CIDR do
   @doc """
   Checks if an IP address is in the provided CIDR.
   """
-  def match(%CIDR{ ip: { a0, b0, c0, d0 }, mask: mask } = _cidr, { a1, b1, c1, d1 } = _ip) do
-    cidr_value = (a0 <<< 24) ||| (b0 <<< 16) ||| (c0 <<< 8) ||| d0
-    ip_value = (a1 <<< 24) ||| (b1 <<< 16) ||| (c1 <<< 8) ||| d1
+  def match(%CIDR{ip: {a, b, c, d}, mask: mask}, {e, f, g, h}) do
+    cidr_value = (a <<< 24) ||| (b <<< 16) ||| (c <<< 8) ||| d
+    ip_value   = (e <<< 24) ||| (f <<< 16) ||| (g <<< 8) ||| h
     (cidr_value >>> (32 - mask)) == (ip_value >>> (32 - mask))
   end
   def match(_address, _mask), do: false
@@ -98,7 +98,7 @@ defmodule CIDR do
     { a1, b1, c1, d1 }
   end
 
-  def is_ipv6({a, b, c, d, e, f, g, h}) when
+  defp is_ipv6({a, b, c, d, e, f, g, h}) do
     a in 0..65535 and
     b in 0..65535 and
     c in 0..65535 and
@@ -106,21 +106,22 @@ defmodule CIDR do
     e in 0..65535 and
     f in 0..65535 and
     g in 0..65535 and
-    h in 0..65535,  do: true
-  def is_ipv6(_),   do: false
+    h in 0..65535
+  end
+  defp is_ipv6(_), do: false
 
-  def is_ipv4({a, b, c, d}) when
+  defp is_ipv4({a, b, c, d}) do
     a in 0..255 and
     b in 0..255 and
     c in 0..255 and
-    d in 0..255,  do: true
-  def is_ipv4(_), do: false
+    d in 0..255
+  end
+  defp is_ipv4(_), do: false
 
-  def mask_by_ip(address) do
+  defp mask_by_ip(address) do
     cond do
-      address |> is_ipv4  ->  32
-      address |> is_ipv6  -> 128
-      true                ->  -1
+      is_ipv4(address) ->  32
+      is_ipv6(address) -> 128
     end
   end
 

--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -32,7 +32,7 @@ defmodule CIDR do
     ip_address = address |> String.to_char_list |> :inet.parse_address
     do_parse(ip_address, mask)
   end
-  
+
   @doc "Only bitstrings can be parsed"
   def parse(_other) do
     {:error, "Not a bitstring"}
@@ -71,7 +71,7 @@ defmodule CIDR do
   def hosts(cidr) do
     1 <<< (32 - cidr.mask)
   end
-  
+
   @doc """
   Returns the lowest IP address covered.
   """
@@ -84,7 +84,7 @@ defmodule CIDR do
     d1  = ((x >>>  0) &&& 0xFF)
     { a1, b1, c1, d1 }
   end
-  
+
   @doc """
   Returns the highest IP address covered.
   """

--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -20,9 +20,26 @@ defmodule CIDR do
     %CIDR{ cidr | mask: mask }
   end
 
-  def is_cidr(cidr) when is_map(cidr), do: cidr.__struct__ == CIDR
-  def is_cidr(string) when is_bitstring(string), do: string |> parse |> is_cidr
-  def is_cidr(_), do: false
+  @doc """
+  Check whether the argument is a CIDR value.
+
+  ## Examples
+
+      iex> CIDR.is_cidr?(%CIDR{ip: {192, 168, 1, 254}, mask: 32})
+      true
+
+      iex> CIDR.is_cidr?("192.168.1.254/32")
+      true
+  """
+  def is_cidr?(cidr) when is_map(cidr) do
+    cidr.__struct__ == CIDR
+  end
+  def is_cidr?(string) when is_bitstring(string) do
+    string
+    |> parse
+    |> is_cidr?
+  end
+  def is_cidr?(_), do: false
 
   @doc """
   Checks if an IP address is in the provided CIDR.

--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -8,6 +8,14 @@ defmodule CIDR do
 
   defstruct ip: nil, mask: 32
 
+  @doc """
+  Set the `mask` of a `cidr` struct.
+
+  ## Examples
+
+      iex> CIDR.set_mask(%CIDR{ip: {192, 168, 1, 254}, mask: 32}, 16)
+      %CIDR{ip: {192, 168, 1, 254}, mask: 16}
+  """
   def set_mask(cidr, mask) when mask in 0..32 do
     %CIDR{ cidr | mask: mask }
   end

--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -65,7 +65,7 @@ defmodule CIDR do
   Returns the number of hosts covered.
   """
   def hosts(cidr) do
-    1 <<< (32 - cidr.mask)
+    1 <<< (mask_by_ip(cidr.ip) - cidr.mask)
   end
 
   @doc """

--- a/test/cidr_test.exs
+++ b/test/cidr_test.exs
@@ -2,7 +2,7 @@ defmodule CIDRTest do
   use ExUnit.Case
   doctest CIDR
 
-  import CIDR, only: [parse: 1, min: 1, max: 1]
+  import CIDR
 
   test "127.0.0.1/32 is valid" do
     assert CIDR.is_cidr?("127.0.0.1/32") == true
@@ -52,48 +52,4 @@ defmodule CIDRTest do
     assert "1.2.3.4/24" |> CIDR.parse |> CIDR.match({1, 2, 3, 200})
     assert "1.2.3.4/24" |> CIDR.parse |> CIDR.match({1, 2, 3, 255})
   end
-
-  test "Returns number of hosts" do
-    assert ("1.2.3.4/32" |> CIDR.parse |> CIDR.hosts) == 1
-    assert ("1.2.3.4/31" |> CIDR.parse |> CIDR.hosts) == 2
-    assert ("1.2.3.4/30" |> CIDR.parse |> CIDR.hosts) == 4
-    assert ("1.2.3.4/29" |> CIDR.parse |> CIDR.hosts) == 8
-    assert ("1.2.3.4/28" |> CIDR.parse |> CIDR.hosts) == 16
-    assert ("1.2.3.4/27" |> CIDR.parse |> CIDR.hosts) == 32
-    assert ("1.2.3.4/26" |> CIDR.parse |> CIDR.hosts) == 64
-    assert ("1.2.3.4/25" |> CIDR.parse |> CIDR.hosts) == 128
-    assert ("1.2.3.4/24" |> CIDR.parse |> CIDR.hosts) == 256
-    assert ("1.2.3.4/23" |> CIDR.parse |> CIDR.hosts) == 512
-    assert ("1.2.3.4/22" |> CIDR.parse |> CIDR.hosts) == 1024
-    assert ("1.2.3.4/21" |> CIDR.parse |> CIDR.hosts) == 2048
-    assert ("1.2.3.4/20" |> CIDR.parse |> CIDR.hosts) == 4096
-    assert ("1.2.3.4/19" |> CIDR.parse |> CIDR.hosts) == 8192
-    assert ("1.2.3.4/18" |> CIDR.parse |> CIDR.hosts) == 16384
-    assert ("1.2.3.4/17" |> CIDR.parse |> CIDR.hosts) == 32768
-    assert ("1.2.3.4/16" |> CIDR.parse |> CIDR.hosts) == 65536
-    assert ("1.2.3.4/15" |> CIDR.parse |> CIDR.hosts) == 131072
-    assert ("1.2.3.4/14" |> CIDR.parse |> CIDR.hosts) == 262144
-    assert ("1.2.3.4/13" |> CIDR.parse |> CIDR.hosts) == 524288
-    assert ("1.2.3.4/12" |> CIDR.parse |> CIDR.hosts) == 1048576
-    assert ("1.2.3.4/11" |> CIDR.parse |> CIDR.hosts) == 2097152
-    assert ("1.2.3.4/10" |> CIDR.parse |> CIDR.hosts) == 4194304
-    assert ("1.2.3.4/9"  |> CIDR.parse |> CIDR.hosts) == 8388608
-    assert ("1.2.3.4/8"  |> CIDR.parse |> CIDR.hosts) == 16777216
-    assert ("1.2.3.4/7"  |> CIDR.parse |> CIDR.hosts) == 33554432
-    assert ("1.2.3.4/6"  |> CIDR.parse |> CIDR.hosts) == 67108864
-    assert ("1.2.3.4/5"  |> CIDR.parse |> CIDR.hosts) == 134217728
-    assert ("1.2.3.4/4"  |> CIDR.parse |> CIDR.hosts) == 268435456
-    assert ("1.2.3.4/3"  |> CIDR.parse |> CIDR.hosts) == 536870912
-    assert ("1.2.3.4/2"  |> CIDR.parse |> CIDR.hosts) == 1073741824
-    assert ("1.2.3.4/1"  |> CIDR.parse |> CIDR.hosts) == 2147483648
-    assert ("1.2.3.4/0"  |> CIDR.parse |> CIDR.hosts) == 4294967296
-  end
-
-  test "Returns correct min/max IP addresses." do
-    assert ("1.2.3.4/24"       |> parse |> min) == { 1, 2, 3, 0 }
-    assert ("1.2.3.4/24"       |> parse |> max) == { 1, 2, 3, 255 }
-    assert ("192.168.100.0/22" |> parse |> min) == { 192, 168, 100, 0 }
-    assert ("192.168.100.0/22" |> parse |> max) == { 192, 168, 103, 255 }
-  end
-
 end

--- a/test/cidr_test.exs
+++ b/test/cidr_test.exs
@@ -5,39 +5,39 @@ defmodule CIDRTest do
   import CIDR, only: [parse: 1, min: 1, max: 1]
 
   test "127.0.0.1/32 is valid" do
-    assert CIDR.is_cidr("127.0.0.1/32") == true
+    assert CIDR.is_cidr?("127.0.0.1/32") == true
   end
 
   test "127.0.0.1/64 is invalid" do
-    assert CIDR.is_cidr("127.0.0.1/64") == false
+    assert CIDR.is_cidr?("127.0.0.1/64") == false
   end
 
   test "127.0.0.1/test is invalid" do
-    assert CIDR.is_cidr("127.0.0.1/test") == false
+    assert CIDR.is_cidr?("127.0.0.1/test") == false
   end
 
   test "test/32 is invalid" do
-    assert CIDR.is_cidr("test/32") == false
+    assert CIDR.is_cidr?("test/32") == false
   end
 
   test "127.0.0.1/32/64 is invalid" do
-    assert CIDR.is_cidr("127.0.0.1/32/64") == false
+    assert CIDR.is_cidr?("127.0.0.1/32/64") == false
   end
 
   test "false is invalid" do
-    assert CIDR.is_cidr(false) == false
+    assert CIDR.is_cidr?(false) == false
   end
 
   test "Parse 127.0.0.1" do
-    assert "127.0.0.1" |> CIDR.parse |> CIDR.is_cidr
+    assert "127.0.0.1" |> CIDR.parse |> CIDR.is_cidr?
   end
 
   test "Parse 127.0.0.1/24" do
-    assert "127.0.0.1/24" |> CIDR.parse |> CIDR.is_cidr
+    assert "127.0.0.1/24" |> CIDR.parse |> CIDR.is_cidr?
   end
 
   # Match
-  
+
   test "Matches exactly" do
     assert ("1.2.3.4" |> CIDR.parse |> CIDR.match({1, 1, 1, 1})) == false
     assert ("1.2.3.4" |> CIDR.parse |> CIDR.match({1, 2, 3, 3})) == false
@@ -45,14 +45,14 @@ defmodule CIDRTest do
     assert ("1.2.3.4" |> CIDR.parse |> CIDR.match({1, 2, 3, 5})) == false
     assert ("1.2.3.4" |> CIDR.parse |> CIDR.match({255, 255, 255, 255})) == false
   end
-  
+
   test "Matches /24" do
     assert "1.2.3.4/24" |> CIDR.parse |> CIDR.match({1, 2, 3, 1})
     assert "1.2.3.4/24" |> CIDR.parse |> CIDR.match({1, 2, 3, 100})
     assert "1.2.3.4/24" |> CIDR.parse |> CIDR.match({1, 2, 3, 200})
     assert "1.2.3.4/24" |> CIDR.parse |> CIDR.match({1, 2, 3, 255})
   end
-  
+
   test "Returns number of hosts" do
     assert ("1.2.3.4/32" |> CIDR.parse |> CIDR.hosts) == 1
     assert ("1.2.3.4/31" |> CIDR.parse |> CIDR.hosts) == 2
@@ -88,7 +88,7 @@ defmodule CIDRTest do
     assert ("1.2.3.4/1"  |> CIDR.parse |> CIDR.hosts) == 2147483648
     assert ("1.2.3.4/0"  |> CIDR.parse |> CIDR.hosts) == 4294967296
   end
-  
+
   test "Returns correct min/max IP addresses." do
     assert ("1.2.3.4/24"       |> parse |> min) == { 1, 2, 3, 0 }
     assert ("1.2.3.4/24"       |> parse |> max) == { 1, 2, 3, 255 }

--- a/test/cidr_test.exs
+++ b/test/cidr_test.exs
@@ -1,5 +1,6 @@
 defmodule CIDRTest do
   use ExUnit.Case
+  doctest CIDR
 
   import CIDR, only: [parse: 1, min: 1, max: 1]
 


### PR DESCRIPTION
Hi Constantin,

I've came across your library and wanted to put in the effort to have it support IPv6. I have made an abundance of changes (I hope you don't mind or feel offended&mdash;just started cracking and this is the result).

The main change is based on the following: CIDR notation like `"192.168.1.1/0"` doesn't make any sense. CIDR to me is based on ranges, so that's what I ended up implementing.

This breaks backwards compatability, but I hope you don't mind since v1.0.0 isn't out yet.

Tests still need to be written, but I wanted to get this out there so you can take a look.

Regards, 
Laurens
