### PR TITLE
Add inch-ci reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,7 @@ otp_release:
     - 17.4
 after_success:
   - "mix compile && mix coveralls.travis"
+after_script:
+  - "MIX_ENV=docs mix deps.get"
+  - "MIX_ENV=docs mix inch.report"
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Hex.pm Version](http://img.shields.io/hexpm/v/cidr.svg)](https://hex.pm/packages/cidr)
 [![Build Status](https://travis-ci.org/c-rack/cidr-elixir.png?branch=master)](https://travis-ci.org/c-rack/cidr-elixir)
 [![Coverage Status](https://coveralls.io/repos/c-rack/cidr-elixir/badge.svg?branch=&service=github)](https://coveralls.io/github/c-rack/cidr-elixir?branch=)
+[![Documentation Status](https://inch-ci.org/github/c-rack/cidr-elixir)](https://inch-ci.org/github/c-rack/cidr-elixir.svg)
 
 [Classless Inter-Domain Routing](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
 (CIDR) utilities for [Elixir](http://www.elixir-lang.org/)

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule CIDR.Mixfile do
         {:earmark,     "~> 0.1",  only: [:dev, :docs]},
         {:ex_doc,      "~> 0.10", only: [:dev, :docs]},
         {:excoveralls, "~> 0.4",  only: [:dev, :test]},
+        {:inch_ex,                only: :docs}
       ],
       description: "Classless Inter-Domain Routing (CIDR) for Elixir",
       docs: [


### PR DESCRIPTION
Inch CI is continuous integration for documentation regressions. They offer a free service and check docs automatically. Not everything they report is always right, but I've found their false positive rate to be quite low.
