### PR TITLE
Problem: start/end may be dangerous names for struct field

### DIFF
--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -5,7 +5,7 @@ defmodule CIDR do
   Classless Inter-Domain Routing (CIDR)
   """
 
-  defstruct start: nil, end: nil, mask: nil, hosts: nil
+  defstruct first: nil, last: nil, start: nil, end: nil, mask: nil, hosts: nil
 
   @doc """
   Check whether the argument is a CIDR value.
@@ -130,10 +130,12 @@ defmodule CIDR do
     address |> String.to_char_list |> :inet.parse_address
   end
 
-  defp create(start, last, mask, hosts) do
+  defp create(first, last, mask, hosts) do
     %CIDR{
-      start: start,
-      end:   last,
+      first: first,
+      last:  last,
+      start: first, # Deprecated, use "first" instead
+      end:   last,  # Deprecated, use "last" instead
       mask:  mask,
       hosts: hosts
     }

--- a/test/cidr_test.exs
+++ b/test/cidr_test.exs
@@ -40,14 +40,14 @@ defmodule CIDRTest do
 
   test "Start and end of IPv4 address range" do
     cidr = "127.0.0.1/24" |> CIDR.parse
-    assert cidr.start == {127, 0, 0, 0}
-    assert cidr.end   == {127, 0, 0, 255}
+    assert cidr.first == {127, 0, 0, 0}
+    assert cidr.last  == {127, 0, 0, 255}
   end
 
   test "Start and end of IPv6 address range" do
     cidr = "::1/24" |> CIDR.parse
-    assert cidr.start == {0, 0, 0, 0, 0, 0, 0, 0}
-    assert cidr.end   == {0, 255, 65535, 65535, 65535, 65535, 65535, 65535}
+    assert cidr.first == {0, 0, 0, 0, 0, 0, 0, 0}
+    assert cidr.last  == {0, 255, 65535, 65535, 65535, 65535, 65535, 65535}
   end
 
   test "Parse of single IP should return exactly 1 host" do


### PR DESCRIPTION
Solution: add additional first/last fields and deprecate start/end

See #26
