### PR TITLE
Avoid Elixir 1.4 compiler warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule CIDR.Mixfile do
         source_ref: "v#{@version}",
         source_url: "https://github.com/c-rack/cidr-elixir"
       ],
-      package: package,
+      package: package(),
       test_coverage: [tool: ExCoveralls],
       version: @version
     ]


### PR DESCRIPTION
Avoiding the `variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name` warning on Elixir 1.4+.

Thanks!