### PR TITLE
Fix build warnings

### DIFF
--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -215,10 +215,10 @@ defmodule CIDR do
     parse(address, mask |> int)
   end
   # Validate that mask is valid
-  defp parse(address, mask) when tuple_size(address) == 4 and not mask in 0..32 do
+  defp parse(address, mask) when tuple_size(address) == 4 and not(mask in 0..32) do
     {:error, "Invalid mask #{mask}"}
   end
-  defp parse(address, mask) when tuple_size(address) == 8 and not mask in 0..128 do
+  defp parse(address, mask) when tuple_size(address) == 8 and not(mask in 0..128) do
     {:error, "Invalid mask #{mask}"}
   end
   # Everything is fine
@@ -235,7 +235,7 @@ defmodule CIDR do
   end
 
   defp parse_address(address) do
-    address |> String.to_char_list |> :inet.parse_address
+    address |> String.to_charlist |> :inet.parse_address
   end
 
   defp create(first, last, mask, hosts) do


### PR DESCRIPTION
```elixir
==> cidr
Compiling 1 file (.ex)
warning: "not expr1 in expr2" is deprecated. Instead use "expr1 not in expr2" if you require Elixir v1.5+, or "not(expr1 in expr2)" if you have to support earlier Elixir versions
  lib/cidr.ex:218

warning: "not expr1 in expr2" is deprecated. Instead use "expr1 not in expr2" if you require Elixir v1.5+, or "not(expr1 in expr2)" if you have to support earlier Elixir versions
  lib/cidr.ex:221

warning: String.to_char_list/1 is deprecated. Use String.to_charlist/1 instead
  lib/cidr.ex:238
```