### PR TITLE
Added IPv4 deaggregation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ iex(10)> cidr |> CIDR.match("1.2.3.1000")
 {:error, "Tuple is not a valid IP address."}
 ```
 
+IPv4 deaggregation works as well. It returns a list of the largest possible networks for an IPv4 range in the format of `$first_ip-$last_ip`:
+
+```elixir
+iex(1)> CIDR.parse_range("192.168.1.0-192.168.2.0")
+[
+  %CIDR{first: {192, 168, 1, 0}, hosts: 256, last: {192, 168, 1, 255}, mask: 24},
+  %CIDR{first: {192, 168, 2, 0}, hosts: 1, last: {192, 168, 2, 0}, mask: 32}
+]
+```
+
 ## Contribution
 
 See [Collective Code Construction Contract (C4)](http://rfc.zeromq.org/spec:42/C4/)

--- a/test/cidr_test.exs
+++ b/test/cidr_test.exs
@@ -194,5 +194,25 @@ defmodule CIDRTest do
     assert CIDR.subnet?(CIDR.parse("10.0.0.128/25"), CIDR.parse("10.0.0.0/24"))
   end
 
+  test "IPv4 Range" do
+    assert CIDR.parse_range("192.168.1.0") == %CIDR{first: {192, 168, 1, 0}, hosts: 1, last: {192, 168, 1, 0}, mask: 32}
+    assert CIDR.parse_range("192.168.1.0-") == {:error, :einval}
+    assert CIDR.parse_range("-192.168.1.0") == {:error, :einval}
+    assert CIDR.parse_range("192.168.1.0-192.168.2.0") == [
+      %CIDR{first: {192, 168, 1, 0}, hosts: 256, last: {192, 168, 1, 255}, mask: 24},
+      %CIDR{first: {192, 168, 2, 0}, hosts: 1, last: {192, 168, 2, 0}, mask: 32}
+    ]
+    assert CIDR.parse_range("2001::/126") == %CIDR{
+      first: {8193, 0, 0, 0, 0, 0, 0, 0},
+      hosts: 4,
+      last: {8193, 0, 0, 0, 0, 0, 0, 3},
+      mask: 126
+    }
+    assert CIDR.parse_range("192.168.1.0/32-192.168.2.0/32") == [
+      %CIDR{first: {192, 168, 1, 0}, hosts: 256, last: {192, 168, 1, 255}, mask: 24},
+      %CIDR{first: {192, 168, 2, 0}, hosts: 1, last: {192, 168, 2, 0}, mask: 32}
+    ]
+  end
+
 end
 


### PR DESCRIPTION
Added IPv4 deaggregation feature. 

Example:
```elixir
iex(1)> CIDR.parse_range("192.168.1.0-192.168.2.0")
[
  %CIDR{first: {192, 168, 1, 0}, hosts: 256, last: {192, 168, 1, 255}, mask: 24},
  %CIDR{first: {192, 168, 2, 0}, hosts: 1, last: {192, 168, 2, 0}, mask: 32}
]
```

It takes a lower and higher IPv4 address, separated by a `-` and returns the list of the largest possible CIDRs that fulfill that range.

Only IPv4 for now.