### PR TITLE
Fix not expr1 in expr2 deprecation

### DIFF
--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -235,11 +235,11 @@ defmodule CIDR do
   end
 
   # Validate that mask is valid
-  defp parse(address, mask) when tuple_size(address) == 4 and mask not in 0..32 do
+  defp parse(address, mask) when tuple_size(address) == 4 and not (mask in 0..32) do
     {:error, "Invalid mask #{mask}"}
   end
 
-  defp parse(address, mask) when tuple_size(address) == 8 and mask not in 0..128 do
+  defp parse(address, mask) when tuple_size(address) == 8 and not (mask in 0..128) do
     {:error, "Invalid mask #{mask}"}
   end
 


### PR DESCRIPTION
Fixes deprecation warning:

```
warning: "not expr1 in expr2" is deprecated. Instead use "expr1 not in expr2" if you require Elixir v1.5+, or "not(expr1 in expr2)" if you have to support earlier Elixir versions
```

It appears we [support Elixir 1.3](https://github.com/c-rack/cidr-elixir/blob/master/mix.exs#L13) so we'd need to use the "not(expr1 in expr2)" format. 