### PR TITLE
Run non-controversial formatter fixes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -235,11 +235,11 @@ defmodule CIDR do
   end
 
   # Validate that mask is valid
-  defp parse(address, mask) when tuple_size(address) == 4 and not (mask in 0..32) do
+  defp parse(address, mask) when tuple_size(address) == 4 and mask not in 0..32 do
     {:error, "Invalid mask #{mask}"}
   end
 
-  defp parse(address, mask) when tuple_size(address) == 8 and not (mask in 0..128) do
+  defp parse(address, mask) when tuple_size(address) == 8 and mask not in 0..128 do
     {:error, "Invalid mask #{mask}"}
   end
 
@@ -373,9 +373,9 @@ defmodule CIDR do
     end
   end
 
-  defp range_reduce_inner(lower, higher, step, acc)  do
+  defp range_reduce_inner(lower, higher, step, acc) do
     outer_test = (lower ||| 1 <<< step) != lower
-    inner_test = (lower ||| 0xFFFFFFFF >>> ((32 - 1) - step)) > higher
+    inner_test = (lower ||| 0xFFFFFFFF >>> (32 - 1 - step)) > higher
 
     case outer_test && !inner_test do
       true -> range_reduce_inner(lower, higher, step + 1, acc)

--- a/mix.exs
+++ b/mix.exs
@@ -47,5 +47,4 @@ defmodule CIDR.Mixfile do
       }
     }
   end
-
 end


### PR DESCRIPTION
Run non-controversial formatter fixes.  Excluded fixes include the
single-line comments, and no parens in the `Enum.map`.

Also add `.formatter.exs` config file for formatter so you can run:
`mix format`