### PR TITLE
Resolve compiler warning with Bitwise module

### DIFF
--- a/lib/cidr.ex
+++ b/lib/cidr.ex
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 defmodule CIDR do
-  use Bitwise
+  import Bitwise
 
   @moduledoc """
   Classless Inter-Domain Routing (CIDR)


### PR DESCRIPTION
The `Bitwise` module now wants to be `import`ed rather than `use`d

https://github.com/elixir-lang/elixir/commit/1a9e59cd4d97988a66087978e65ce89c87122593